### PR TITLE
Fall back to default OANDA data set

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'oanda_currency'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -109,6 +109,7 @@ class Money
         begin
           rate = store.get_rate(from.iso_code, to.iso_code)
           raise unless rate
+
           rate
         rescue StandardError
           raise UnknownRate
@@ -191,7 +192,7 @@ class Money
       def raise_or_return(response, base, quote)
         rsp_body = JSON.parse(response.body)
         rsp_code = rsp_body.fetch('code')
-        rsp_message = rsp_body.fetch('messsage')
+        rsp_message = rsp_body.fetch('message')
 
         case response.status
         when 200

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -3,19 +3,21 @@
 require 'money'
 require 'money/rates_store/rate_removal_support'
 require 'open-uri'
+require 'faraday'
 
 class Money
   module Bank
     # # Raised when there is an unexpected error in extracting exchange rates
     # # from Oanda
-    class OandaCurrencyFetchError < Error
-    end
+    class OandaCurrencyFetchError < Error; end
+    class UnknownCurrency < Error; end
 
     # VariableExchange bank that handles fetching exchange rates from Oanda
     # and storing them in the in memory rates store.
     class OandaCurrency < Money::Bank::VariableExchange
       SERVICE_HOST = 'web-services.oanda.com'
       SERVICE_PATH = '/rates/api/v2/rates/candle.json'
+      DEFAULT_DATA_SET = 'OANDA'
 
       # @return [Hash] Stores the currently known rates.
       attr_reader :rates
@@ -48,11 +50,12 @@ class Money
         end
       end
 
-      def initialize(st, access_key, white_list_currencies)
+      def initialize(st, access_key, white_list_currencies, data_set)
         super(st)
         @store.extend Money::RatesStore::RateRemovalSupport
         @access_key = access_key
         @white_list_currencies = white_list_currencies
+        @data_set = data_set
       end
 
       ##
@@ -102,7 +105,7 @@ class Money
       def get_rate(from, to)
         expire_rates
 
-        fetch_rates(from.iso_code, to.iso_code) if !store.get_rate(from.iso_code, to.iso_code)
+        fetch_rates(from.iso_code, to.iso_code) unless store.get_rate(from.iso_code, to.iso_code)
         begin
           rate = store.get_rate(from.iso_code, to.iso_code)
           raise unless rate
@@ -131,8 +134,12 @@ class Money
       ##
       # Makes an api call to populate all of the exchange rates in the in
       # memory store.
+      #
+      # Using Faraday to capture responses with error messages from the api,
+      # instead of generic OpenURI::HTTPError 400 Bad Request from [URI::HTTP]#read
       def fetch_rates(base, quote)
-        data = build_uri(base, quote).read
+        response = Faraday.get(build_uri(base, quote).to_s)
+        data = raise_or_return(response, base, quote)
         extract_rates(data)
       end
 
@@ -148,7 +155,7 @@ class Money
             "base=#{base}",
             "quote=#{quote}",
             "date_time=#{(Time.now.utc - 86_400).strftime('%Y-%m-%d')}",
-            'data_set=MUFG',
+            "data_set=#{@data_set}",
             "api_key=#{access_key}"
           ].join('&')
         )
@@ -166,7 +173,7 @@ class Money
           to_currency = rate.fetch('quote_currency')
 
           unless @white_list_currencies.include?(from_currency) &&
-                   @white_list_currencies.include?(from_currency)
+                   @white_list_currencies.include?(to_currency)
             next
           end
 
@@ -178,6 +185,28 @@ class Money
         end
       rescue StandardError
         raise OandaCurrencyFetchError
+      end
+
+      # OANDA API docs: https://developer.oanda.com/exchange-rates-api/#cmp--responses
+      def raise_or_return(response, base, quote)
+        rsp_body = JSON.parse(response.body)
+        rsp_code = rsp_body.fetch('code')
+        rsp_message = rsp_body.fetch('messsage')
+
+        case response.status
+        when 200
+          response.body
+        when 400
+          raise OandaCurrencyFetchError, rsp_message unless rsp_code == 1
+
+          @data_set = DEFAULT_DATA_SET
+          # return a JSON response body only if successful, else will fail with OpenURI::HTTPError
+          build_uri(base, quote).read
+        else
+          raise OandaCurrencyFetchError, rsp_message
+        end
+      rescue OpenURI::HTTPError
+        raise UnknownCurrency, rsp_message
       end
     end
   end

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -190,7 +190,7 @@ class Money
 
       # OANDA API docs: https://developer.oanda.com/exchange-rates-api/#cmp--responses
       def raise_or_return(response, base, quote)
-        return build_uri(base, quote).read if response.status == 200
+        return response.body if response.status == 200
 
         rsp_body = JSON.parse(response.body)
         rsp_code = rsp_body.fetch('code')

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -190,13 +190,13 @@ class Money
 
       # OANDA API docs: https://developer.oanda.com/exchange-rates-api/#cmp--responses
       def raise_or_return(response, base, quote)
+        return build_uri(base, quote).read if response.status == 200
+
         rsp_body = JSON.parse(response.body)
         rsp_code = rsp_body.fetch('code')
         rsp_message = rsp_body.fetch('message')
 
         case response.status
-        when 200
-          response.body
         when 400
           raise OandaCurrencyFetchError, rsp_message unless rsp_code == 1
 

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -202,6 +202,7 @@ class Money
 
           current_data_set = @data_set
           @data_set = DEFAULT_DATA_SET
+          # Attempt a second API call with default data set (OANDA)
           # return a JSON response body only if successful, else will fail with OpenURI::HTTPError
           build_uri(base, quote).read
           @data_set = current_data_set

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -185,7 +185,7 @@ class Money
           )
         end
       rescue StandardError
-        raise OandaCurrencyFetchError
+        raise OandaCurrencyFetchError, 'Error parsing rates or adding rates to store'
       end
 
       # OANDA API docs: https://developer.oanda.com/exchange-rates-api/#cmp--responses
@@ -204,8 +204,9 @@ class Money
           @data_set = DEFAULT_DATA_SET
           # Attempt a second API call with default data set (OANDA)
           # return a JSON response body only if successful, else will fail with OpenURI::HTTPError
-          build_uri(base, quote).read
+          response = build_uri(base, quote).read
           @data_set = current_data_set
+          response
         else
           raise OandaCurrencyFetchError, rsp_message
         end

--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -200,13 +200,16 @@ class Money
         when 400
           raise OandaCurrencyFetchError, rsp_message unless rsp_code == 1
 
+          current_data_set = @data_set
           @data_set = DEFAULT_DATA_SET
           # return a JSON response body only if successful, else will fail with OpenURI::HTTPError
           build_uri(base, quote).read
+          @data_set = current_data_set
         else
           raise OandaCurrencyFetchError, rsp_message
         end
       rescue OpenURI::HTTPError
+        @data_set = current_data_set
         raise UnknownCurrency, rsp_message
       end
     end

--- a/lib/oanda_currency.rb
+++ b/lib/oanda_currency.rb
@@ -1,2 +1,4 @@
 require 'money/bank/oanda_currency'
 require 'money/rates_store/rate_removal_support'
+
+require 'pry-byebug'

--- a/lib/oanda_currency.rb
+++ b/lib/oanda_currency.rb
@@ -1,4 +1,2 @@
 require 'money/bank/oanda_currency'
 require 'money/rates_store/rate_removal_support'
-
-require 'pry-byebug'

--- a/oanda_currency.gemspec
+++ b/oanda_currency.gemspec
@@ -11,9 +11,11 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_development_dependency 'ffi'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec', '>= 3.0.0'
   s.add_development_dependency 'yard', '>= 0.5.8'
 
+  s.add_dependency 'faraday'
   s.add_dependency 'money', '6.13.1'
 
   s.files =  Dir.glob('{lib,spec}/**/*')

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -81,7 +81,7 @@ describe Money::Bank::OandaCurrency do
       before do
         failed_response = instance_double(Faraday::Response,
                                           status: 400,
-                                          body: { code: 1, messsage: 'Oh crap' }.to_json)
+                                          body: { code: 1, message: 'Oh crap' }.to_json)
         allow(Faraday).to receive(:get).and_return(failed_response)
       end
 

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -78,13 +78,6 @@ describe Money::Bank::OandaCurrency do
     end
 
     context 'when the currency is not found upstream' do
-      before do
-        failed_response = instance_double(Faraday::Response,
-                                          status: 400,
-                                          body: { code: 1, message: 'Dunno why but I still fail after falling back to OANDA' }.to_json)
-        allow(Faraday).to receive(:get).and_return(failed_response)
-      end
-
       it 'should fall back to default data set and attempt another API call' do
         allow(@bank).to receive_message_chain(:build_uri, :read).and_return(anything)
         @bank.store.add_rate(:VND, :USD, 0.6)
@@ -92,6 +85,13 @@ describe Money::Bank::OandaCurrency do
         @bank.get_rate(Money::Currency.wrap(:VND), Money::Currency.wrap(:USD))
         expect(@bank.store.instance_variable_get('@index'))
           .to include('VND_TO_USD')
+      end
+
+      before do
+        failed_response = instance_double(Faraday::Response,
+                                          status: 400,
+                                          body: { code: 1, message: 'Dunno why but I still fail after falling back to OANDA' }.to_json)
+        allow(Faraday).to receive(:get).and_return(failed_response)
       end
 
       it 'should raise UnknownCurrency error when second call with default data set fails' do

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -186,13 +186,13 @@ describe Money::Bank::OandaCurrency do
 
   describe 'private#build_uri' do
     it 'uses MUFG data set' do
-      expect(@bank.send(:build_uri, 'JPY', 'EUR').query.split('&')).to(
+      expect(@bank.send(:build_uri, 'JPY', 'EUR', 'MUFG').query.split('&')).to(
         include('data_set=MUFG'))
     end
 
     it 'grabs previous day rate info' do
       Timecop.freeze(Time.now.utc)
-      expect(@bank.send(:build_uri, 'JPY', 'EUR').query.split('&')).to(
+      expect(@bank.send(:build_uri, 'JPY', 'EUR', 'MUFG').query.split('&')).to(
         include("date_time=#{(Time.now - 86_400).strftime('%Y-%m-%d')}"))
     end
   end

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -87,6 +87,14 @@ describe Money::Bank::OandaCurrency do
           .to include('VND_TO_USD')
       end
 
+      it 'should not change @data_set' do
+        allow(@bank).to receive_message_chain(:build_uri, :read).and_return(anything)
+        @bank.store.add_rate(:VND, :USD, 0.6)
+
+        expect { @bank.get_rate(Money::Currency.wrap(:VND), Money::Currency.wrap(:USD)) }
+          .not_to change { @bank.instance_variable_get(:@data_set) }
+      end
+
       before do
         failed_response = instance_double(Faraday::Response,
                                           status: 400,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,5 @@ end
 
 def load_rate_http_response(name)
   f = File.expand_path("../rates/#{name}.html", __FILE__)
-  File.read(f, :encoding => 'iso-8859-1')
+  File.read(f, encoding: 'iso-8859-1')
 end


### PR DESCRIPTION
## Context

Fixes a bug found when we fail to dynamically convert MYR to or from any currency. The reason seems to be because the data set that we are using for fetching exchange rates - MUFG - does not have rates for MYR.

This PR allows the rate fetcher to switch to `OANDA` as the default data set when initial request with a configured data set fails with a certain error code from OANDA API.

I also try using Faraday to capture and return more indicative error responses. Previously, open-uri#read to make API call raises only a generic 400 Bad Request for any reason that the call fails (missing currency error, authorization error, rate limit error etc all raise the same exception), which is not very helpful for debugging.

I also add the console and pry-byebug to assist debugging when we want to expand the code in the future.

## How to Test
0. Confirm on `master` branch that the following raises an `OpenURI::HTTPError`. In `bin/console`
(the current currencies data set is hard coded as 'MUFG')
```ruby
st = Money::RatesStore::Memory.new
access_key = <please DM me>
currencies = ['JPY', 'MYR']
bank = Money::Bank::OandaCurrency.new(st, access_key, currencies)
bank.get_rate(Money::Currency.wrap(:JPY), Money::Currency.wrap(:MYR)).to_f
```

1. Switch to this PR branch, create a new bank in the console, `bin/console`:
```ruby
st = Money::RatesStore::Memory.new
access_key = <please DM me>
currencies = ['JPY', 'MYR']
data_set = 'MUFG'
bank = Money::Bank::OandaCurrency.new(st, access_key, currencies, data_set)
```
2. Get MYR conversion rate
```ruby
bank.get_rate(Money::Currency.wrap(:JPY), Money::Currency.wrap(:MYR)).to_f
# => should give you a 0.03 ish rate
```
3. The data set should be reset again back to the current data set (MUFG)
```ruby
bank.instance_variable_get(:@data_set)
```