### PR TITLE
Use the latest midpoint

### DIFF
--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -16,7 +16,7 @@ class Money
     # and storing them in the in memory rates store.
     class OandaCurrency < Money::Bank::VariableExchange
       SERVICE_HOST = 'web-services.oanda.com'
-      SERVICE_PATH = '/rates/api/v2/rates/candle.json'
+      SERVICE_PATH = '/rates/api/v2/rates/spot.json'
       DEFAULT_DATA_SET = 'OANDA'
 
       # @return [Hash] Stores the currently known rates.
@@ -155,7 +155,6 @@ class Money
           query: [
             "base=#{base}",
             "quote=#{quote}",
-            "date_time=#{(Time.now.utc - 86_400).strftime('%Y-%m-%d')}",
             "data_set=#{data_set}",
             "api_key=#{access_key}"
           ].join('&')
@@ -181,7 +180,7 @@ class Money
           store.add_rate(
             from_currency,
             to_currency,
-            BigDecimal(rate.fetch('average_midpoint'))
+            BigDecimal(rate.fetch('midpoint'))
           )
         end
       rescue StandardError

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -197,11 +197,5 @@ describe Money::Bank::OandaCurrency do
       expect(@bank.send(:build_uri, 'JPY', 'EUR', 'MUFG').query.split('&')).to(
         include('data_set=MUFG'))
     end
-
-    it 'grabs previous day rate info' do
-      Timecop.freeze(Time.now.utc)
-      expect(@bank.send(:build_uri, 'JPY', 'EUR', 'MUFG').query.split('&')).to(
-        include("date_time=#{(Time.now - 86_400).strftime('%Y-%m-%d')}"))
-    end
   end
 end


### PR DESCRIPTION
The candle endpoint provides the previous day's value.
This PR change to fetche the latest data from the [spot endpoint](https://developer.oanda.com/exchange-rates-api/#get-/v2/rates/spot.-ext-).