### PR TITLE
Remove whitelist for base currencies

### DIFF
--- a/lib/money/bank/oanda_currency.rb
+++ b/lib/money/bank/oanda_currency.rb
@@ -173,10 +173,7 @@ class Money
           from_currency = rate.fetch('base_currency')
           to_currency = rate.fetch('quote_currency')
 
-          unless @white_list_currencies.include?(from_currency) &&
-                   @white_list_currencies.include?(to_currency)
-            next
-          end
+          next unless @white_list_currencies.include?(to_currency)
 
           store.add_rate(
             from_currency,

--- a/spec/oanda_currency_with_json_spec.rb
+++ b/spec/oanda_currency_with_json_spec.rb
@@ -204,4 +204,89 @@ describe Money::Bank::OandaCurrency do
         include("date_time=#{(Time.now - 86_400).strftime('%Y-%m-%d')}"))
     end
   end
+
+  describe 'private#extract_rates' do
+    let(:data) {
+      {
+        "meta": {
+          "effective_params": {
+            "data_set": "OANDA",
+            "base_currencies": [
+              "CHF",
+              "USD"
+            ],
+            "quote_currencies": [
+              "EUR",
+              "INR"
+            ],
+            "date_time": "2022-05-09T07:15:00+00:00",
+            "decimal_places": 5,
+            "fields": [
+              "averages"
+            ]
+          },
+          "endpoint": "candle",
+          "request_time": "2022-05-10T07:29:07+00:00",
+          "skipped_currency_pairs": []
+        },
+        "quotes": [
+          {
+            "base_currency": "CHF",
+            "quote_currency": "EUR",
+            "start_time": "2022-05-09T07:15:00+00:00",
+            "open_time": "2022-05-09T07:15:00+00:00",
+            "close_time": "2022-05-10T07:14:59+00:00",
+            "average_bid": "0.95441",
+            "average_ask": "0.95460",
+            "average_midpoint": "0.95450"
+          },
+          {
+            "base_currency": "CHF",
+            "quote_currency": "INR",
+            "start_time": "2022-05-09T07:15:00+00:00",
+            "open_time": "2022-05-09T07:15:00+00:00",
+            "close_time": "2022-05-10T07:14:59+00:00",
+            "average_bid": "77.76657",
+            "average_ask": "77.91848",
+            "average_midpoint": "77.84252"
+          },
+          {
+            "base_currency": "USD",
+            "quote_currency": "EUR",
+            "start_time": "2022-05-09T07:15:00+00:00",
+            "open_time": "2022-05-09T07:15:00+00:00",
+            "close_time": "2022-05-10T07:14:59+00:00",
+            "average_bid": "0.94741",
+            "average_ask": "0.94758",
+            "average_midpoint": "0.94750"
+          },
+          {
+            "base_currency": "USD",
+            "quote_currency": "INR",
+            "start_time": "2022-05-09T07:15:00+00:00",
+            "open_time": "2022-05-09T07:15:00+00:00",
+            "close_time": "2022-05-10T07:14:59+00:00",
+            "average_bid": "77.20334",
+            "average_ask": "77.33839",
+            "average_midpoint": "77.27086"
+          }
+        ]
+      }.to_json
+    }
+    context "when the rate's from_currency is not in whitelist" do
+      it 'still add the rate' do
+        @bank.send(:extract_rates, data)
+        expect(@bank.store.instance_variable_get('@index'))
+          .to include('CHF_TO_EUR')
+      end
+    end
+
+    context "when the rate's to_currency is not in whitelist" do
+      it 'should not get the rate' do
+        @bank.send(:extract_rates, data)
+        expect(@bank.store.instance_variable_get('@index'))
+          .not_to include('USD_TO_INR')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Fixes degica/hats#13898
We recently have more merchants processing orders with base currencies that are not listed in KOMOJU's [available currencies](https://github.com/degica/hats/blob/master/lib/constants.rb) such as `INR` or `BRL`. These merchants are getting errors processing payments as we are getting exchange rates only for whitelisted KOMOJU's available currencies.

This allows KOMOJU to fetch exchange rates for all base currencies while restricting quote currencies to KOMOJU's list.

## How to Test
0. `rspec` should pass
1. Create a new bank in the console, `bin/console`:
```ruby
st = Money::RatesStore::Memory.new
access_key = <please DM me>
currencies = ['JPY', 'USD']
data_set = 'OANDA'
bank = Money::Bank::OandaCurrency.new(st, access_key, currencies, data_set)
```
2. Get INR conversion rate
```ruby
bank.get_rate(Money::Currency.wrap(:INR), Money::Currency.wrap(:USD)).to_f
# => should give you a 0.01295 ish rate
```
3. On HATS, use this branch of oanda_currency gem in Gemfile
```ruby
gem 'oanda_currency', git: 'https://github.com/degica/oanda_currency', branch: 'remove-base-currency-whitelist'
```
Then in `rails c`, confirm that you can convert `INR` to `JPY`
```ruby
Money.new(100, 'INR').exchange_to(JPY).amount
```